### PR TITLE
Fix api initialization

### DIFF
--- a/src/main/java/com/kucoin/sdk/rest/impl/retrofit/AuthRetrofitAPIImpl.java
+++ b/src/main/java/com/kucoin/sdk/rest/impl/retrofit/AuthRetrofitAPIImpl.java
@@ -3,24 +3,23 @@
  */
 package com.kucoin.sdk.rest.impl.retrofit;
 
-import java.lang.reflect.ParameterizedType;
-
 import com.kucoin.sdk.factory.RetrofitFactory;
+
+import java.lang.reflect.ParameterizedType;
 
 /**
  * Created by chenshiwei on 2019/1/10.
  */
 public class AuthRetrofitAPIImpl<T> extends AbstractRetrofitAPIImpl<T> {
 
-    private volatile boolean inited;
-    private T apiImpl;
+    private volatile T apiImpl;
 
     @Override
     public T getAPIImpl() {
-        if (inited)
+        if (apiImpl != null)
             return apiImpl;
         synchronized (getClass()) {
-            if (inited)
+            if (apiImpl != null)
               return apiImpl;
             @SuppressWarnings("unchecked")
             Class<T> tClass = (Class<T>) ((ParameterizedType) this.getClass().getGenericSuperclass())

--- a/src/main/java/com/kucoin/sdk/rest/impl/retrofit/PublicRetrofitAPIImpl.java
+++ b/src/main/java/com/kucoin/sdk/rest/impl/retrofit/PublicRetrofitAPIImpl.java
@@ -3,24 +3,23 @@
  */
 package com.kucoin.sdk.rest.impl.retrofit;
 
-import java.lang.reflect.ParameterizedType;
-
 import com.kucoin.sdk.factory.RetrofitFactory;
+
+import java.lang.reflect.ParameterizedType;
 
 /**
  * Created by chenshiwei on 2019/1/10.
  */
 public class PublicRetrofitAPIImpl<T> extends AbstractRetrofitAPIImpl<T> {
 
-    private volatile boolean inited;
-    private T apiImpl;
+    private volatile T apiImpl;
 
     @Override
     public T getAPIImpl() {
-        if (inited)
+        if (apiImpl != null)
             return apiImpl;
         synchronized (getClass()) {
-            if (inited)
+            if (apiImpl != null)
                 return apiImpl;
             @SuppressWarnings("unchecked")
             Class<T> tClass = (Class<T>) ((ParameterizedType) this.getClass().getGenericSuperclass())


### PR DESCRIPTION
Currently `inited` was never set to `true`, so api was initialized on each call, leading to degraded performance. I don't see point of having two attributes `apiImpl` and `inited`, having just `apiImpl` should be enough.