### PR TITLE
Update Get Full Order Book API to v3 that requires authentication

### DIFF
--- a/src/main/java/com/kucoin/sdk/KucoinClientBuilder.java
+++ b/src/main/java/com/kucoin/sdk/KucoinClientBuilder.java
@@ -84,7 +84,7 @@ public class KucoinClientBuilder {
         if (timeAPI == null) timeAPI = new TimeAPIAdapter(baseUrl);
         if (commonAPI == null) commonAPI = new CommonAPIAdapter(baseUrl);
         if (symbolAPI == null) symbolAPI = new SymbolAPIAdaptor(baseUrl);
-        if (orderBookAPI == null) orderBookAPI = new OrderBookAPIAdapter(baseUrl);
+        if (orderBookAPI == null) orderBookAPI = new OrderBookAPIAdapter(baseUrl, apiKey, secret, passPhrase, apiKeyVersion);
         if (historyAPI == null) historyAPI = new HistoryAPIAdapter(baseUrl);
         return new KucoinRestClientImpl(this);
     }

--- a/src/main/java/com/kucoin/sdk/rest/adapter/OrderBookAPIAdapter.java
+++ b/src/main/java/com/kucoin/sdk/rest/adapter/OrderBookAPIAdapter.java
@@ -3,7 +3,7 @@
  */
 package com.kucoin.sdk.rest.adapter;
 
-import com.kucoin.sdk.rest.impl.retrofit.PublicRetrofitAPIImpl;
+import com.kucoin.sdk.rest.impl.retrofit.AuthRetrofitAPIImpl;
 import com.kucoin.sdk.rest.interfaces.OrderBookAPI;
 import com.kucoin.sdk.rest.interfaces.retrofit.OrderBookAPIRetrofit;
 import com.kucoin.sdk.rest.response.Level3Response;
@@ -14,10 +14,14 @@ import java.io.IOException;
 /**
  * Created by chenshiwei on 2019/1/22.
  */
-public class OrderBookAPIAdapter extends PublicRetrofitAPIImpl<OrderBookAPIRetrofit> implements OrderBookAPI {
+public class OrderBookAPIAdapter extends AuthRetrofitAPIImpl<OrderBookAPIRetrofit> implements OrderBookAPI {
 
-    public OrderBookAPIAdapter(String baseUrl) {
+    public OrderBookAPIAdapter(String baseUrl, String apiKey, String secret, String passPhrase, Integer apiKeyVersion) {
         this.baseUrl = baseUrl;
+        this.apiKey = apiKey;
+        this.secret = secret;
+        this.passPhrase = passPhrase;
+        this.apiKeyVersion = apiKeyVersion;
     }
 
     @Override

--- a/src/main/java/com/kucoin/sdk/rest/interfaces/retrofit/OrderBookAPIRetrofit.java
+++ b/src/main/java/com/kucoin/sdk/rest/interfaces/retrofit/OrderBookAPIRetrofit.java
@@ -21,7 +21,7 @@ public interface OrderBookAPIRetrofit {
     @GET("api/v1/market/orderbook/level2_20")
     Call<KucoinResponse<OrderBookResponse>> getTop20Level2OrderBook(@Query("symbol") String symbol);
 
-    @GET("api/v2/market/orderbook/level2")
+    @GET("api/v3/market/orderbook/level2")
     Call<KucoinResponse<OrderBookResponse>> getFullLevel2OrderBook(@Query("symbol") String symbol);
 
     @GET("api/v2/market/orderbook/level3")


### PR DESCRIPTION
The method RestClient.orderBookAPI().getFullLevel2OrderBook returns a 404 not found because the API Get Full Order Book(aggregated) was updated to V3 and now also requires authentication as described here: 

https://docs.kucoin.com/#get-part-order-book-aggregated

I fixed updating the orderBookAPI and now extends AuthRetrofitAPIImpl.