### PR TITLE
Fix WebSocket SocketTimeoutException adding onFailure on KucoinAPICallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,32 +133,112 @@ wsClient.close();
 ##### Listen for changes to the order boock for ETH-BTC and KCS-BTC
 
 ```java
-kucoinPublicWSClient.onTicker(response -> {
-            System.out.println(response);
-        }, "ETH-BTC", "KCS-BTC");
-kucoinPublicWSClient.onLevel2Data(response -> {
-            System.out.println(response);
-        }, "ETH-BTC", "KCS-BTC");
-kucoinPublicWSClient.onMatchExecutionData(response -> {
-            System.out.println(response);
-        });
-kucoinPublicWSClient.onLevel3Data(response -> {
-            System.out.println(response);
-        }, "ETH-BTC", "KCS-BTC");
+kucoinPublicWSClient.onTicker(new KucoinAPICallback<KucoinEvent<TickerChangeEvent>>() {
+
+	@Override
+	public void onResponse(KucoinEvent<TickerChangeEvent> response) throws KucoinApiException {
+		System.out.println(response);
+	}
+
+	@Override
+	public void onFailure(Throwable cause) {
+		System.out.println("WS connection failed. Reconnecting. cause:" + cause.getMessage());
+		//reinitializeWSConnection();	//implement this method
+	}
+        	
+}, "ETH-BTC", "KCS-BTC");
+
+kucoinPublicWSClient.onLevel2Data(new KucoinAPICallback<KucoinEvent<Level2ChangeEvent>>() {
+
+	@Override
+	public void onResponse(KucoinEvent<Level2ChangeEvent> response) throws KucoinApiException {
+		System.out.println(response);
+	}
+
+	@Override
+	public void onFailure(Throwable cause) {
+		System.out.println("WS connection failed. Reconnecting. cause:" + cause.getMessage());
+		//reinitializeWSConnection();	//implement this method
+	}
+        	
+}, "ETH-BTC", "KCS-BTC");
+
+
+kucoinPublicWSClient.onMatchExecutionData(new KucoinAPICallback<KucoinEvent<MatchExcutionChangeEvent>>() {
+
+	@Override
+	public void onResponse(KucoinEvent<MatchExcutionChangeEvent> response) throws KucoinApiException {
+		System.out.println(response);
+	}
+
+	@Override
+	public void onFailure(Throwable cause) {
+		System.out.println("WS connection failed. Reconnecting. cause:" + cause.getMessage());
+		//reinitializeWSConnection();	//implement this method
+	}
+        	
+}, "ETH-BTC", "KCS-BTC");
+
+
+kucoinPublicWSClient.onLevel3Data(new KucoinAPICallback<KucoinEvent<Level3ChangeEvent>>() {
+
+	@Override
+	public void onResponse(KucoinEvent<Level3ChangeEvent> response) throws KucoinApiException {
+		System.out.println(response);
+	}
+
+	@Override
+	public void onFailure(Throwable cause) {
+		System.out.println("WS connection failed. Reconnecting. cause:" + cause.getMessage());
+		//reinitializeWSConnection();	//implement this method
+	}
+
+}, "ETH-BTC", "KCS-BTC");
+
 ```
+
 #### Private Channels
 
 ##### Listen for account balance changes
+
 ```java
-kucoinPrivateWSClient.onAccountBalance(response -> {
-            System.out.println(response);
-        });
+
+kucoinPrivateWSClient.onAccountBalance(new KucoinAPICallback<KucoinEvent<AccountChangeEvent>>() {
+
+	@Override
+	public void onResponse(KucoinEvent<AccountChangeEvent> response) throws KucoinApiException {
+		System.out.println(response);
+	}
+
+	@Override
+	public void onFailure(Throwable cause) {
+		System.out.println("WS connection failed. Reconnecting. cause:" + cause.getMessage());
+		//reinitializeWSConnection();	//implement this method
+	}
+        	
+});
+
 ```
+
 ##### Listen for order activate message
+
 ```java
-kucoinPrivateWSClient.onOrderActivate(response -> {
-            System.out.println(response);
-        }, "ETH-BTC", "KCS-BTC");
+
+kucoinPrivateWSClient.onOrderActivate(new KucoinAPICallback<KucoinEvent<OrderActivateEvent>>() {
+
+	@Override
+	public void onResponse(KucoinEvent<OrderActivateEvent> response) throws KucoinApiException {
+		System.out.println(response);
+	}
+
+	@Override
+	public void onFailure(Throwable cause) {
+		System.out.println("WS connection failed. Reconnecting. cause:" + cause.getMessage());
+		//reinitializeWSConnection();	//implement this method
+	}
+
+}, "ETH-BTC", "KCS-BTC");
+
 ```
 
 ## Testing

--- a/src/main/java/com/kucoin/sdk/KucoinClientBuilder.java
+++ b/src/main/java/com/kucoin/sdk/KucoinClientBuilder.java
@@ -84,7 +84,7 @@ public class KucoinClientBuilder {
         if (timeAPI == null) timeAPI = new TimeAPIAdapter(baseUrl);
         if (commonAPI == null) commonAPI = new CommonAPIAdapter(baseUrl);
         if (symbolAPI == null) symbolAPI = new SymbolAPIAdaptor(baseUrl);
-        if (orderBookAPI == null) orderBookAPI = new OrderBookAPIAdapter(baseUrl);
+        if (orderBookAPI == null) orderBookAPI = new OrderBookAPIAdapter(baseUrl, apiKey, secret, passPhrase, apiKeyVersion);
         if (historyAPI == null) historyAPI = new HistoryAPIAdapter(baseUrl);
         return new KucoinRestClientImpl(this);
     }

--- a/src/main/java/com/kucoin/sdk/factory/HttpClientFactory.java
+++ b/src/main/java/com/kucoin/sdk/factory/HttpClientFactory.java
@@ -3,6 +3,8 @@
  */
 package com.kucoin.sdk.factory;
 
+import java.util.concurrent.TimeUnit;
+
 import com.kucoin.sdk.rest.interceptor.AuthenticationInterceptor;
 import okhttp3.Dispatcher;
 import okhttp3.Interceptor;

--- a/src/main/java/com/kucoin/sdk/rest/adapter/OrderBookAPIAdapter.java
+++ b/src/main/java/com/kucoin/sdk/rest/adapter/OrderBookAPIAdapter.java
@@ -3,7 +3,7 @@
  */
 package com.kucoin.sdk.rest.adapter;
 
-import com.kucoin.sdk.rest.impl.retrofit.PublicRetrofitAPIImpl;
+import com.kucoin.sdk.rest.impl.retrofit.AuthRetrofitAPIImpl;
 import com.kucoin.sdk.rest.interfaces.OrderBookAPI;
 import com.kucoin.sdk.rest.interfaces.retrofit.OrderBookAPIRetrofit;
 import com.kucoin.sdk.rest.response.Level3Response;
@@ -14,10 +14,14 @@ import java.io.IOException;
 /**
  * Created by chenshiwei on 2019/1/22.
  */
-public class OrderBookAPIAdapter extends PublicRetrofitAPIImpl<OrderBookAPIRetrofit> implements OrderBookAPI {
+public class OrderBookAPIAdapter extends AuthRetrofitAPIImpl<OrderBookAPIRetrofit> implements OrderBookAPI {
 
-    public OrderBookAPIAdapter(String baseUrl) {
+    public OrderBookAPIAdapter(String baseUrl, String apiKey, String secret, String passPhrase, Integer apiKeyVersion) {
         this.baseUrl = baseUrl;
+        this.apiKey = apiKey;
+        this.secret = secret;
+        this.passPhrase = passPhrase;
+        this.apiKeyVersion = apiKeyVersion;
     }
 
     @Override

--- a/src/main/java/com/kucoin/sdk/rest/interfaces/retrofit/OrderBookAPIRetrofit.java
+++ b/src/main/java/com/kucoin/sdk/rest/interfaces/retrofit/OrderBookAPIRetrofit.java
@@ -21,7 +21,7 @@ public interface OrderBookAPIRetrofit {
     @GET("api/v1/market/orderbook/level2_20")
     Call<KucoinResponse<OrderBookResponse>> getTop20Level2OrderBook(@Query("symbol") String symbol);
 
-    @GET("api/v2/market/orderbook/level2")
+    @GET("api/v3/market/orderbook/level2")
     Call<KucoinResponse<OrderBookResponse>> getFullLevel2OrderBook(@Query("symbol") String symbol);
 
     @GET("api/v2/market/orderbook/level3")

--- a/src/main/java/com/kucoin/sdk/websocket/KucoinAPICallback.java
+++ b/src/main/java/com/kucoin/sdk/websocket/KucoinAPICallback.java
@@ -11,5 +11,7 @@ import com.kucoin.sdk.exception.KucoinApiException;
 public interface KucoinAPICallback<T> {
 
     void onResponse(T response) throws KucoinApiException;
+    
+    void onFailure(Throwable cause);
 
 }

--- a/src/main/java/com/kucoin/sdk/websocket/PrintCallback.java
+++ b/src/main/java/com/kucoin/sdk/websocket/PrintCallback.java
@@ -20,4 +20,9 @@ public class PrintCallback<T> implements KucoinAPICallback<T> {
         LOGGER.debug("Got response: {}", response);
     }
 
+	@Override
+	public void onFailure(Throwable cause) {
+		LOGGER.debug("Got exception: {}", cause);
+	}
+
 }

--- a/src/main/java/com/kucoin/sdk/websocket/listener/KucoinPrivateWebsocketListener.java
+++ b/src/main/java/com/kucoin/sdk/websocket/listener/KucoinPrivateWebsocketListener.java
@@ -81,6 +81,19 @@ public class KucoinPrivateWebsocketListener extends WebSocketListener {
     @Override
     public void onFailure(WebSocket webSocket, Throwable t, Response response) {
         LOGGER.error("Error on private socket", t);
+        
+        if( orderActivateCallback != null ) {
+        	orderActivateCallback.onFailure(t);
+        }
+        if( accountChangeCallback != null ) {
+        	accountChangeCallback.onFailure(t);
+        }
+        if( orderChangeCallback != null ) {
+        	orderChangeCallback.onFailure(t);
+        }
+        if( advancedOrderCallback != null ) {
+        	advancedOrderCallback.onFailure(t);
+        }
     }
 
     private JsonNode tree(String text) {

--- a/src/main/java/com/kucoin/sdk/websocket/listener/KucoinPublicWebsocketListener.java
+++ b/src/main/java/com/kucoin/sdk/websocket/listener/KucoinPublicWebsocketListener.java
@@ -95,6 +95,31 @@ public class KucoinPublicWebsocketListener extends WebSocketListener {
     @Override
     public void onFailure(WebSocket webSocket, Throwable t, Response response) {
         LOGGER.error("Error on private socket", t);
+        
+        if( tickerCallback != null ) {
+        	tickerCallback.onFailure(t);
+        }
+        if( level2Callback != null ) {
+        	level2Callback.onFailure(t);
+        }
+        if( level2Depth5Callback != null ) {
+        	level2Depth5Callback.onFailure(t);
+        }
+        if( level2Depth50Callback != null ) {
+        	level2Depth50Callback.onFailure(t);
+        }
+        if( matchDataCallback != null ) {
+        	matchDataCallback.onFailure(t);
+        }
+        if( level3Callback != null ) {
+        	level3Callback.onFailure(t);
+        }
+        if( level3V2Callback != null ) {
+        	level3V2Callback.onFailure(t);
+        }
+        if( snapshotCallback != null ) {
+        	snapshotCallback.onFailure(t);
+        }
     }
 
     private JsonNode tree(String text) {

--- a/src/test/java/com/kucoin/sdk/KucoinPrivateWSClientTest.java
+++ b/src/test/java/com/kucoin/sdk/KucoinPrivateWSClientTest.java
@@ -3,6 +3,7 @@
  */
 package com.kucoin.sdk;
 
+import com.kucoin.sdk.exception.KucoinApiException;
 import com.kucoin.sdk.model.enums.ApiKeyVersionEnum;
 import com.kucoin.sdk.model.enums.PrivateChannelEnum;
 import com.kucoin.sdk.rest.request.AccountTransferV2Request;
@@ -10,8 +11,10 @@ import com.kucoin.sdk.rest.request.OrderCreateApiRequest;
 import com.kucoin.sdk.rest.request.StopOrderCreateRequest;
 import com.kucoin.sdk.rest.response.AccountBalancesResponse;
 import com.kucoin.sdk.rest.response.OrderCreateResponse;
+import com.kucoin.sdk.websocket.KucoinAPICallback;
 import com.kucoin.sdk.websocket.event.AccountChangeEvent;
 import com.kucoin.sdk.websocket.event.AdvancedOrderEvent;
+import com.kucoin.sdk.websocket.event.KucoinEvent;
 import com.kucoin.sdk.websocket.event.OrderActivateEvent;
 import com.kucoin.sdk.websocket.event.OrderChangeEvent;
 import org.hamcrest.core.Is;
@@ -64,12 +67,33 @@ public class KucoinPrivateWSClientTest {
         AtomicReference<OrderActivateEvent> event = new AtomicReference<>();
         CountDownLatch gotEvent = new CountDownLatch(1);
 
+        kucoinPrivateWSClient.onOrderActivate(new KucoinAPICallback<KucoinEvent<OrderActivateEvent>>() {
+
+			@Override
+			public void onResponse(KucoinEvent<OrderActivateEvent> response) throws KucoinApiException {
+	            LOGGER.info("Got response");
+	            event.set(response.getData());
+	            kucoinPrivateWSClient.unsubscribe(PrivateChannelEnum.ORDER, "ETH-BTC", "KCS-BTC");
+	            gotEvent.countDown();
+			}
+
+			@Override
+			public void onFailure(Throwable cause) {
+				System.out.println("WS connection failed. Reconnecting. cause:" + cause.getMessage());
+
+				//reinitializeWSConnection();	//implement this method
+			}
+        	
+        }, "ETH-BTC", "KCS-BTC");
+        
+        /*
         kucoinPrivateWSClient.onOrderActivate(response -> {
             LOGGER.info("Got response");
             event.set(response.getData());
             kucoinPrivateWSClient.unsubscribe(PrivateChannelEnum.ORDER, "ETH-BTC", "KCS-BTC");
             gotEvent.countDown();
         }, "ETH-BTC", "KCS-BTC");
+        */
 
         Thread.sleep(1000);
 
@@ -93,12 +117,33 @@ public class KucoinPrivateWSClientTest {
         AtomicReference<OrderChangeEvent> event = new AtomicReference<>();
         CountDownLatch gotEvent = new CountDownLatch(1);
 
+        kucoinPrivateWSClient.onOrderChange(new KucoinAPICallback<KucoinEvent<OrderChangeEvent>>() {
+
+			@Override
+			public void onResponse(KucoinEvent<OrderChangeEvent> response) throws KucoinApiException {
+	            LOGGER.info("Got response");
+	            event.set(response.getData());
+	            kucoinPrivateWSClient.unsubscribe(PrivateChannelEnum.ORDER_CHANGE, "ETH-BTC", "BTC-USDT");
+	            gotEvent.countDown();
+			}
+
+			@Override
+			public void onFailure(Throwable cause) {
+				System.out.println("WS connection failed. Reconnecting. cause:" + cause.getMessage());
+
+				//reinitializeWSConnection();	//implement this method
+			}
+        	
+        }, "ETH-BTC", "BTC-USDT");
+        
+        /*
         kucoinPrivateWSClient.onOrderChange(response -> {
             LOGGER.info("Got response");
             event.set(response.getData());
             kucoinPrivateWSClient.unsubscribe(PrivateChannelEnum.ORDER_CHANGE, "ETH-BTC", "BTC-USDT");
             gotEvent.countDown();
         }, "ETH-BTC", "BTC-USDT");
+        */
 
         Thread.sleep(1000);
 
@@ -122,12 +167,33 @@ public class KucoinPrivateWSClientTest {
         AtomicReference<AccountChangeEvent> event = new AtomicReference<>();
         CountDownLatch gotEvent = new CountDownLatch(1);
 
+        kucoinPrivateWSClient.onAccountBalance(new KucoinAPICallback<KucoinEvent<AccountChangeEvent>>() {
+
+			@Override
+			public void onResponse(KucoinEvent<AccountChangeEvent> response) throws KucoinApiException {
+	            LOGGER.info("Got response");
+	            event.set(response.getData());
+	            kucoinPrivateWSClient.unsubscribe(PrivateChannelEnum.ACCOUNT);
+	            gotEvent.countDown();
+			}
+
+			@Override
+			public void onFailure(Throwable cause) {
+				System.out.println("WS connection failed. Reconnecting. cause:" + cause.getMessage());
+
+				//reinitializeWSConnection();	//implement this method
+			}
+        	
+        });
+        
+        /*
         kucoinPrivateWSClient.onAccountBalance(response -> {
             LOGGER.info("Got response");
             event.set(response.getData());
             kucoinPrivateWSClient.unsubscribe(PrivateChannelEnum.ACCOUNT);
             gotEvent.countDown();
         });
+        */
 
         Thread.sleep(1000);
 
@@ -158,12 +224,33 @@ public class KucoinPrivateWSClientTest {
         AtomicReference<AdvancedOrderEvent> event = new AtomicReference<>();
         CountDownLatch gotEvent = new CountDownLatch(1);
 
+        kucoinPrivateWSClient.onAdvancedOrder(new KucoinAPICallback<KucoinEvent<? extends AdvancedOrderEvent>>() {
+
+			@Override
+			public void onResponse(KucoinEvent<? extends AdvancedOrderEvent> response) throws KucoinApiException {
+	            LOGGER.info("Got response {}", response);
+	            event.set(response.getData());
+	            kucoinPrivateWSClient.unsubscribe(PrivateChannelEnum.ADVANCED_ORDER, "ETH-BTC");
+	            gotEvent.countDown();
+			}
+
+			@Override
+			public void onFailure(Throwable cause) {
+				System.out.println("WS connection failed. Reconnecting. cause:" + cause.getMessage());
+
+				//reinitializeWSConnection();	//implement this method
+			}
+        	
+        }, "ETH-BTC");
+        
+        /*
         kucoinPrivateWSClient.onAdvancedOrder(response -> {
             LOGGER.info("Got response {}", response);
             event.set(response.getData());
             kucoinPrivateWSClient.unsubscribe(PrivateChannelEnum.ADVANCED_ORDER, "ETH-BTC");
             gotEvent.countDown();
         }, "ETH-BTC");
+        */
 
         Thread.sleep(1000);
 

--- a/src/test/java/com/kucoin/sdk/KucoinPublicWSClientTest.java
+++ b/src/test/java/com/kucoin/sdk/KucoinPublicWSClientTest.java
@@ -3,11 +3,13 @@
  */
 package com.kucoin.sdk;
 
+import com.kucoin.sdk.exception.KucoinApiException;
 import com.kucoin.sdk.model.enums.ApiKeyVersionEnum;
 import com.kucoin.sdk.model.enums.PublicChannelEnum;
 import com.kucoin.sdk.rest.request.OrderCreateApiRequest;
 import com.kucoin.sdk.rest.response.OrderCreateResponse;
 import com.kucoin.sdk.rest.response.TickerResponse;
+import com.kucoin.sdk.websocket.KucoinAPICallback;
 import com.kucoin.sdk.websocket.event.*;
 import org.hamcrest.core.Is;
 import org.junit.AfterClass;
@@ -56,11 +58,31 @@ public class KucoinPublicWSClientTest {
         AtomicReference<TickerResponse> event = new AtomicReference<>();
         CountDownLatch gotEvent = new CountDownLatch(1);
 
+        kucoinPublicWSClient.onTicker(new KucoinAPICallback<KucoinEvent<TickerChangeEvent>>() {
+
+			@Override
+			public void onResponse(KucoinEvent<TickerChangeEvent> response) throws KucoinApiException {
+	            event.set(response.getData());
+	            kucoinPublicWSClient.unsubscribe(PublicChannelEnum.TICKER, "ETH-BTC", "KCS-BTC");
+	            gotEvent.countDown();
+			}
+
+			@Override
+			public void onFailure(Throwable cause) {
+				System.out.println("WS connection failed. Reconnecting. cause:" + cause.getMessage());
+
+				//reinitializeWSConnection();	//implement this method
+			}
+        	
+        }, "ETH-BTC", "KCS-BTC");
+        
+        /*
         kucoinPublicWSClient.onTicker(response -> {
             event.set(response.getData());
             kucoinPublicWSClient.unsubscribe(PublicChannelEnum.TICKER, "ETH-BTC", "KCS-BTC");
             gotEvent.countDown();
         }, "ETH-BTC", "KCS-BTC");
+        */
 
         // Make some actual executions
         buyAndSell();
@@ -74,11 +96,31 @@ public class KucoinPublicWSClientTest {
         AtomicReference<Level2ChangeEvent> event = new AtomicReference<>();
         CountDownLatch gotEvent = new CountDownLatch(1);
 
+        kucoinPublicWSClient.onLevel2Data(new KucoinAPICallback<KucoinEvent<Level2ChangeEvent>>() {
+
+			@Override
+			public void onResponse(KucoinEvent<Level2ChangeEvent> response) throws KucoinApiException {
+	            event.set(response.getData());
+	            kucoinPublicWSClient.unsubscribe(PublicChannelEnum.LEVEL2, "ETH-BTC", "KCS-BTC");
+	            gotEvent.countDown();
+			}
+
+			@Override
+			public void onFailure(Throwable cause) {
+				System.out.println("WS connection failed. Reconnecting. cause:" + cause.getMessage());
+
+				//reinitializeWSConnection();	//implement this method
+			}
+        	
+        }, "ETH-BTC", "KCS-BTC");
+        
+        /*
         kucoinPublicWSClient.onLevel2Data(response -> {
             event.set(response.getData());
             kucoinPublicWSClient.unsubscribe(PublicChannelEnum.LEVEL2, "ETH-BTC", "KCS-BTC");
             gotEvent.countDown();
         }, "ETH-BTC", "KCS-BTC");
+        */
 
         // Trigger a market change
         placeOrderAndCancelOrder();
@@ -92,11 +134,31 @@ public class KucoinPublicWSClientTest {
         AtomicReference<Level2Event> event = new AtomicReference<>();
         CountDownLatch gotEvent = new CountDownLatch(1);
 
+        kucoinPublicWSClient.onLevel2Data(5, new KucoinAPICallback<KucoinEvent<Level2Event>>() {
+
+			@Override
+			public void onResponse(KucoinEvent<Level2Event> response) throws KucoinApiException {
+	            event.set(response.getData());
+	            kucoinPublicWSClient.unsubscribe(PublicChannelEnum.LEVEL2_DEPTH5, "ETH-BTC", "BTC-USDT");
+	            gotEvent.countDown();
+			}
+
+			@Override
+			public void onFailure(Throwable cause) {
+				System.out.println("WS connection failed. Reconnecting. cause:" + cause.getMessage());
+
+				//reinitializeWSConnection();	//implement this method
+			}
+        	
+        }, "ETH-BTC", "BTC-USDT");
+        
+        /*
         kucoinPublicWSClient.onLevel2Data(5, response -> {
             event.set(response.getData());
             kucoinPublicWSClient.unsubscribe(PublicChannelEnum.LEVEL2_DEPTH5, "ETH-BTC", "BTC-USDT");
             gotEvent.countDown();
         }, "ETH-BTC", "BTC-USDT");
+        */
 
         // Trigger a market change
         placeOrderAndCancelOrder();
@@ -110,11 +172,30 @@ public class KucoinPublicWSClientTest {
         AtomicReference<Level2Event> event = new AtomicReference<>();
         CountDownLatch gotEvent = new CountDownLatch(1);
 
+        kucoinPublicWSClient.onLevel2Data(50,  new KucoinAPICallback<KucoinEvent<Level2Event>>() {
+
+			@Override
+			public void onResponse(KucoinEvent<Level2Event> response) throws KucoinApiException {
+	            event.set(response.getData());
+	            kucoinPublicWSClient.unsubscribe(PublicChannelEnum.LEVEL2_DEPTH50, "ETH-BTC", "BTC-USDT");
+	            gotEvent.countDown();
+			}
+
+			@Override
+			public void onFailure(Throwable cause) {
+				System.out.println("WS connection failed. Reconnecting. cause:" + cause.getMessage());
+
+				//reinitializeWSConnection();	//implement this method
+			}
+        }, "ETH-BTC", "BTC-USDT");
+        
+        /*
         kucoinPublicWSClient.onLevel2Data(50, response -> {
             event.set(response.getData());
             kucoinPublicWSClient.unsubscribe(PublicChannelEnum.LEVEL2_DEPTH50, "ETH-BTC", "BTC-USDT");
             gotEvent.countDown();
         }, "ETH-BTC", "BTC-USDT");
+        */
 
         // Trigger a market change
         placeOrderAndCancelOrder();
@@ -128,11 +209,31 @@ public class KucoinPublicWSClientTest {
         AtomicReference<MatchExcutionChangeEvent> event = new AtomicReference<>();
         CountDownLatch gotEvent = new CountDownLatch(1);
 
+        kucoinPublicWSClient.onMatchExecutionData(new KucoinAPICallback<KucoinEvent<MatchExcutionChangeEvent>>() {
+
+			@Override
+			public void onResponse(KucoinEvent<MatchExcutionChangeEvent> response) throws KucoinApiException {
+	            event.set(response.getData());
+	            kucoinPublicWSClient.unsubscribe(PublicChannelEnum.MATCH, "ETH-BTC", "KCS-BTC");
+	            gotEvent.countDown();
+			}
+
+			@Override
+			public void onFailure(Throwable cause) {
+				System.out.println("WS connection failed. Reconnecting. cause:" + cause.getMessage());
+
+				//reinitializeWSConnection();	//implement this method
+			}
+        	
+        }, "ETH-BTC", "KCS-BTC");
+        
+        /*
         kucoinPublicWSClient.onMatchExecutionData(response -> {
             event.set(response.getData());
             kucoinPublicWSClient.unsubscribe(PublicChannelEnum.MATCH, "ETH-BTC", "KCS-BTC");
             gotEvent.countDown();
         }, "ETH-BTC", "KCS-BTC");
+		*/
 
         // Make some actual executions
         buyAndSell();
@@ -146,11 +247,31 @@ public class KucoinPublicWSClientTest {
         AtomicReference<Level3ChangeEvent> event = new AtomicReference<>();
         CountDownLatch gotEvent = new CountDownLatch(1);
 
+        kucoinPublicWSClient.onLevel3Data(new KucoinAPICallback<KucoinEvent<Level3ChangeEvent>>() {
+
+			@Override
+			public void onResponse(KucoinEvent<Level3ChangeEvent> response) throws KucoinApiException {
+	            event.set(response.getData());
+	            kucoinPublicWSClient.unsubscribe(PublicChannelEnum.LEVEL3, "ETH-BTC", "KCS-BTC");
+	            gotEvent.countDown();
+			}
+
+			@Override
+			public void onFailure(Throwable cause) {
+				System.out.println("WS connection failed. Reconnecting. cause:" + cause.getMessage());
+
+				//reinitializeWSConnection();	//implement this method
+			}
+        	
+        }, "ETH-BTC", "KCS-BTC");
+        
+        /*
         kucoinPublicWSClient.onLevel3Data(response -> {
             event.set(response.getData());
             kucoinPublicWSClient.unsubscribe(PublicChannelEnum.LEVEL3, "ETH-BTC", "KCS-BTC");
             gotEvent.countDown();
         }, "ETH-BTC", "KCS-BTC");
+        */
 
         // Trigger a market change
         placeOrderAndCancelOrder();
@@ -164,11 +285,31 @@ public class KucoinPublicWSClientTest {
         AtomicReference<Level3Event> event = new AtomicReference<>();
         CountDownLatch gotEvent = new CountDownLatch(1);
 
+        kucoinPublicWSClient.onLevel3Data_V2(new KucoinAPICallback<KucoinEvent<Level3Event>>() {
+
+			@Override
+			public void onResponse(KucoinEvent<Level3Event> response) throws KucoinApiException {
+	            event.set(response.getData());
+	            kucoinPublicWSClient.unsubscribe(PublicChannelEnum.LEVEL3_V2, "ETH-BTC", "BTC-USDT");
+	            gotEvent.countDown();
+			}
+
+			@Override
+			public void onFailure(Throwable cause) {
+				System.out.println("WS connection failed. Reconnecting. cause:" + cause.getMessage());
+
+				//reinitializeWSConnection();	//implement this method
+			}
+        	
+        }, "ETH-BTC", "BTC-USDT");
+        
+        /*
         kucoinPublicWSClient.onLevel3Data_V2(response -> {
             event.set(response.getData());
             kucoinPublicWSClient.unsubscribe(PublicChannelEnum.LEVEL3_V2, "ETH-BTC", "BTC-USDT");
             gotEvent.countDown();
         }, "ETH-BTC", "BTC-USDT");
+        */
 
         // Trigger a market change
         placeOrderAndCancelOrder();
@@ -188,11 +329,33 @@ public class KucoinPublicWSClientTest {
     public void onSnapshot() throws Exception {
         AtomicReference<SnapshotEvent> event = new AtomicReference<>();
         CountDownLatch gotEvent = new CountDownLatch(1);
+        
+        kucoinPublicWSClient.onSnapshot(new KucoinAPICallback<KucoinEvent<SnapshotEvent>>() {
+
+			@Override
+			public void onResponse(KucoinEvent<SnapshotEvent> response) throws KucoinApiException {
+	            event.set(response.getData());
+	            kucoinPublicWSClient.unsubscribe(PublicChannelEnum.SNAPSHOT, "ETH-BTC");
+	            gotEvent.countDown();
+			}
+
+			@Override
+			public void onFailure(Throwable cause) {
+				System.out.println("WS connection failed. Reconnecting. cause:" + cause.getMessage());
+
+				//reinitializeWSConnection();	//implement this method
+			}
+        	
+        }, "ETH-BTC");
+        
+        /*
         kucoinPublicWSClient.onSnapshot(response -> {
             event.set(response.getData());
             kucoinPublicWSClient.unsubscribe(PublicChannelEnum.SNAPSHOT, "ETH-BTC");
             gotEvent.countDown();
         }, "ETH-BTC");
+        */
+        
         placeOrderAndCancelOrder();
         gotEvent.await(20, TimeUnit.SECONDS);
         System.out.println(event.get());


### PR DESCRIPTION
While socket running gets the exception below, The socket can work for a maximum of 1 day without any errors:

```
2022-06-11 13:03:47.876 ERROR 22068 --- [.kucoin.com/...] c.k.s.w.l.KucoinPublicWebsocketListener  : Error on private socket

java.net.SocketTimeoutException: sent ping but didn't receive pong within 30000ms (after 225 successful ping/pongs)
        at okhttp3.internal.ws.RealWebSocket.writePingFrame(RealWebSocket.java:545)
        at okhttp3.internal.ws.RealWebSocket$PingRunnable.run(RealWebSocket.java:529)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
        at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
        at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
```

I fixed adding the KucoinAPICallback.onFailure method, that allow to manage a reconnection programmatically, please look in the tests on KucoinPublicWSClientTest and KucoinPrivateWSClientTest for a reference implementation.
I also updated the Readme.MD with new code, here an example:

```
public void onLevel2Data() throws Exception {
        kucoinPublicWSClient.onLevel2Data(new KucoinAPICallback<KucoinEvent<Level2ChangeEvent>>() {

			@Override
			public void onResponse(KucoinEvent<Level2ChangeEvent> response) throws KucoinApiException {
	            event.set(response.getData());
	            kucoinPublicWSClient.unsubscribe(PublicChannelEnum.LEVEL2, "ETH-BTC", "KCS-BTC");
	            gotEvent.countDown();
			}

			@Override
			public void onFailure(Throwable cause) {
				System.out.println("WS connection failed. Reconnecting. cause:" + cause.getMessage());

				//reinitializeWSConnection();	//implement this method
			}
        	
        }, "ETH-BTC", "KCS-BTC");
}
```

the reinitializeWSConnection() may be something like this:

```
private static KucoinPublicWSClient kucoinPublicWSClient;

public reinitializeWSConnection() {
        kucoinPublicWSClient = new KucoinClientBuilder().withBaseUrl("https://openapi-sandbox.kucoin.com")
                .buildPublicWSClient();

       onLevel2Data();
}

```
