### PR TITLE
WALLET_PROCESSING enum value added to WithdrawStatusEnum

### DIFF
--- a/src/main/java/com/kucoin/sdk/model/enums/WithdrawStatusEnum.java
+++ b/src/main/java/com/kucoin/sdk/model/enums/WithdrawStatusEnum.java
@@ -8,6 +8,7 @@ package com.kucoin.sdk.model.enums;
  */
 public enum WithdrawStatusEnum {
     PROCESSING,
+    WALLET_PROCESSING,
     SUCCESS,
     FAILURE
 }


### PR DESCRIPTION
WALLET_PROCESSING withdraw status is missing in the corresponding enum WithdrawStatusEnum resulting in exceptions being thrown in client code:

```Cannot deserialize value of type `com.kucoin.sdk.model.enums.WithdrawStatusEnum` from String \"WALLET_PROCESSING\": not one of the values accepted for Enum class: [FAILURE, SUCCESS, PROCESSING]\n at [Source: (okhttp3.ResponseBody$BomAwareReader); line: 1, column: 167] (through reference chain: com.kucoin.sdk.rest.response.KucoinResponse[\"data\"]->com.kucoin.sdk.rest.response.Pagination[\"items\"]->java.util.ArrayList[0]->com.kucoin.sdk.rest.response.WithdrawResponse[\"status\"]```